### PR TITLE
Better brand colors of Google and Microsoft

### DIFF
--- a/template/src/data/auth-providers.js
+++ b/template/src/data/auth-providers.js
@@ -30,7 +30,7 @@ const authProviders = [
   },
   {
     id: "google.com",
-    color: "#DB4437",
+    color: "#ea4335",
     icon: <GoogleIcon />,
     name: "Google",
   },


### PR DESCRIPTION
Google is being represented as blue (`#4285f4`) and Microsoft as orange (`#f65314`).

Better suiting colors could be:
Google - red-ish (`#DB4437`) (Google+)
Microsoft - dark blue (`#0078d7`) (Windows default)

PS: My first open-source contribution, advance apologies for any mistake