### PR TITLE
Fix linked accounts not displayed in settings

### DIFF
--- a/template/src/services/authentication.js
+++ b/template/src/services/authentication.js
@@ -432,7 +432,7 @@ authentication.authProviderData = (providerId) => {
     return;
   }
 
-  return providerData.find((authProvider) => authProvider.id === providerId);
+  return providerData.find((authProvider) => authProvider.providerId === providerId);
 };
 
 authentication.signOut = () => {


### PR DESCRIPTION
Linked accounts are not displayed in the settings and can't be unlinked.

This is because in the `providerData` object, each provider has the property `providerId` instead of `id`.

Before fix:
<img width="552" alt="Screenshot 2021-03-05 at 14 33 39" src="https://user-images.githubusercontent.com/67421398/110122327-c870e700-7dbf-11eb-9e34-360ec7dfe364.png">

After fix:
<img width="552" alt="Screenshot 2021-03-05 at 14 35 19" src="https://user-images.githubusercontent.com/67421398/110122615-200f5280-7dc0-11eb-96e9-b68ffade7b25.jpg">